### PR TITLE
fix(setting): make querystring auth false on django storages media bu…

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -231,6 +231,7 @@ if env("AWS_S3_ENABLED"):
             "OPTIONS": {
                 **AWS_S3_CONFIG_OPTIONS,
                 "bucket_name": env("AWS_S3_MEDIA_BUCKET_NAME"),
+                "querystring_auth": False,
                 "location": "media/",
                 "file_overwrite": False,
             },


### PR DESCRIPTION
## Changes

* Make querystring auth  false on django media storage

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [X] tests
- [X] permission checks (tests here too)
- [ ] translations
